### PR TITLE
Support group, server for CoreUpdate

### DIFF
--- a/index.js
+++ b/index.js
@@ -18,6 +18,8 @@ program
   .option('--private-network [guid]', 'guid for an optional private network')
   .option('--monitoring-token [guid]', 'guid for optional rackspace cloud monitoring')
   .option('--key-name [ssh keyname]', 'optional ssh keyname')
+  .option('--updateGroup [group]', 'optional update group')
+  .option('--updateServer [server]', 'optional endpoint for updates')
   .option('--username [username]', 'required or via RACKSPACE_USERNAME env variable')
   .option('--apiKey [apiKey]', 'required or via RACKSPACE_APIKEY env variable')
   .option('--region [region]', 'required or via RACKSPACE_REGION env variable')
@@ -54,6 +56,16 @@ if (program.privateNetwork) {
 }
 if (program.monitoringToken) {
   options.monitoringToken = program.monitoringToken;
+}
+
+options.update = {}
+
+if (program.updateGroup) {
+  options.update.group = program.updateGroup;
+}
+
+if (program.updateServer) {
+  options.update.server = program.updateServer;
 }
 
 var cluster, interval;

--- a/index.js
+++ b/index.js
@@ -28,6 +28,8 @@ program
 var options = {
   type: program.type,
   release: program.release,
+  update: {
+  },
   credentials: {
     username: program.username || process.env.RACKSPACE_USERNAME,
     apiKey: program.apiKey || process.env.RACKSPACE_APIKEY,
@@ -57,8 +59,6 @@ if (program.privateNetwork) {
 if (program.monitoringToken) {
   options.monitoringToken = program.monitoringToken;
 }
-
-options.update = {}
 
 if (program.updateGroup) {
   options.update.group = program.updateGroup;

--- a/index.js
+++ b/index.js
@@ -28,8 +28,7 @@ program
 var options = {
   type: program.type,
   release: program.release,
-  update: {
-  },
+  update: {},
   credentials: {
     username: program.username || process.env.RACKSPACE_USERNAME,
     apiKey: program.apiKey || process.env.RACKSPACE_APIKEY,

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
   },
   "license": "MIT",
   "dependencies": {
-    "coreos-cluster": "~3.0.1",
+    "coreos-cluster": "~3.0.2",
     "colors": "1.0.3",
     "commander": "2.3.0",
     "easy-table": "0.3.0",


### PR DESCRIPTION
This adds support for https://github.com/kenperkins/coreos-cluster/pull/3, just adding options and populating the `update` object.
